### PR TITLE
feat : filter 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,11 @@
 				"sass": "^1.62.1",
 				"swiper": "^9.3.2",
 				"typescript": "^4.9.5",
+				"uuid": "^9.0.0",
 				"web-vitals": "^2.1.4"
 			},
 			"devDependencies": {
+				"@types/uuid": "^9.0.2",
 				"@typescript-eslint/eslint-plugin": "^5.59.8",
 				"@typescript-eslint/parser": "^5.59.8",
 				"eslint": "^8.41.0",
@@ -4270,6 +4272,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
 			"integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+		},
+		"node_modules/@types/uuid": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+			"integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
+			"dev": true
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.4",
@@ -15377,6 +15385,14 @@
 				"websocket-driver": "^0.7.4"
 			}
 		},
+		"node_modules/sockjs/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/source-list-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -16570,9 +16586,9 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+			"integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"sass": "^1.62.1",
 		"swiper": "^9.3.2",
 		"typescript": "^4.9.5",
+		"uuid": "^9.0.0",
 		"web-vitals": "^2.1.4"
 	},
 	"scripts": {
@@ -46,6 +47,7 @@
 		]
 	},
 	"devDependencies": {
+		"@types/uuid": "^9.0.2",
 		"@typescript-eslint/eslint-plugin": "^5.59.8",
 		"@typescript-eslint/parser": "^5.59.8",
 		"eslint": "^8.41.0",

--- a/public/images/React App_files/bundle.js.다운로드
+++ b/public/images/React App_files/bundle.js.다운로드
@@ -3755,7 +3755,7 @@ function invariant(value, message) {
 function warning(cond, message) {
   if (!cond) {
     // eslint-disable-next-line no-console
-    if (typeof console !== "undefined") console.warn(message);
+    if (typeof console !== "undefined") (message);
     try {
       // Welcome to debugging history!
       //
@@ -47489,7 +47489,7 @@ var socketURL = (0,_utils_createSocketURL_js__WEBPACK_IMPORTED_MODULE_8__["defau
 
       exports.LogType = LogType;
 
-      /** @typedef {typeof LogType[keyof typeof LogType]} LogTypeEnum */
+      /** @typedef {typeof LogType[ typeof LogType]} LogTypeEnum */
 
       var LOG_SYMBOL = (typeof Symbol !== "undefined" ? Symbol : function (i) {
         return i;

--- a/public/images/search/search_icon.svg
+++ b/public/images/search/search_icon.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+ // 16pxls (c) by Paul mackenzie <paul@whatspauldoing.com>
+ //
+ // 16pxls is licensed under a
+ // Creative Commons Attribution-ShareAlike 4.0 International License.
+ //
+ // You should have received a copy of the license along with this
+ // work. If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
+-->
+
+<svg fill="#000000" width="800px" height="800px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12.027 9.92L16 13.95 14 16l-4.075-3.976A6.465 6.465 0 0 1 6.5 13C2.91 13 0 10.083 0 6.5 0 2.91 2.917 0 6.5 0 10.09 0 13 2.917 13 6.5a6.463 6.463 0 0 1-.973 3.42zM1.997 6.452c0 2.48 2.014 4.5 4.5 4.5 2.48 0 4.5-2.015 4.5-4.5 0-2.48-2.015-4.5-4.5-4.5-2.48 0-4.5 2.014-4.5 4.5z" fill-rule="evenodd"/>
+</svg>

--- a/src/components/home/HomeSwiper/index.tsx
+++ b/src/components/home/HomeSwiper/index.tsx
@@ -69,7 +69,7 @@ export default function HomeSwiper() {
         // watchSlidesProgress
         // onProgress={(swiper, progress) => {
         //   // todo : nintendo처럼 hover시 slide change가 안 되려면 fillProgressiveBar함수 완성하기
-        //   console.log(progress)
+        //   (progress)
         // }}
       >
         <SwiperSlide className={styles.swiperItem}>

--- a/src/components/search/Filter/index.module.scss
+++ b/src/components/search/Filter/index.module.scss
@@ -1,0 +1,12 @@
+.cover {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  span {
+    padding-right: 1rem;
+  }
+  select {
+    min-width: 200px;
+    height: 35px;
+  }
+}

--- a/src/components/search/Filter/index.tsx
+++ b/src/components/search/Filter/index.tsx
@@ -1,11 +1,49 @@
+import { useRecoilValue } from 'recoil'
+import { SearchQuery, searchQueryState } from '@/recoil/search/queryStringState'
 import React from 'react'
+import styles from './index.module.scss'
+import { useNavigate } from 'react-router-dom'
+import { generateQueryString } from '@/utils/search'
 
 export default function Filter() {
+  const navigation = useNavigate()
+  const query = useRecoilValue(searchQueryState)
+
+  function selectOption(e: React.ChangeEvent<HTMLSelectElement>) {
+    const queryString = generateQueryString<SearchQuery>({ ...query, sort: e.target.value })
+    navigation('/search?' + queryString)
+  }
+
+  function cancleGenre() {
+    if (!query.search && !query.sort) return navigation('/search')
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { genre: _, ...restQuery } = query
+    const params = generateQueryString<SearchQuery>(restQuery)
+    navigation('/search?' + params.toString())
+  }
+
   return (
     <div>
-      Filter
-      <p>가격순, 이름순만 지원가능할 듯 합니다.</p>
-      <p>발매일(최신순)정렬 속성이 api에서 제공되지 않습니다.</p>
+      <div className={styles.cover}>
+        <div className={styles.fillter}>
+          {query.genre && (
+            <>
+              <span>선택된 장르 : </span>
+              <span>{query.genre}</span>
+              <button onClick={cancleGenre}>취소하기</button>
+            </>
+          )}
+        </div>
+        <div className={styles.sort}>
+          <span>정렬 순서 : </span>
+          <select value={query.sort ? query.sort : 'asc'} onChange={selectOption}>
+            <option value="desc">내림차순</option>
+            <option value="asc">오름차순</option>
+            <option value="high">높은 가격 순</option>
+            <option value="low">낮은 가격 순</option>
+          </select>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/search/Genre/index.module.scss
+++ b/src/components/search/Genre/index.module.scss
@@ -13,8 +13,20 @@
   .genreList {
     font-size: 1.2rem;
     padding-top: 1.5rem;
-    li {
+    .current {
+      font-weight: 700;
+    }
+    .genre {
       padding: 0.5rem;
+      transition: all 0.3s ease-in-out;
+      cursor: pointer;
+      a {
+        color: black;
+        text-decoration: none;
+      }
+    }
+    .genre:hover {
+      font-weight: 700;
     }
   }
 }

--- a/src/components/search/Genre/index.tsx
+++ b/src/components/search/Genre/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 import styles from './index.module.scss'
+import { Link } from 'react-router-dom'
+import { useRecoilValue } from 'recoil'
+import { SearchQuery, searchQueryState } from '@/recoil/search/queryStringState'
+import { generateQueryString } from '@/utils/search'
 
 const genres = [
   '액션',
@@ -23,24 +27,23 @@ const genres = [
 ]
 
 export default function Genre() {
-  const addGenre = () => {
-    return null
-  }
+  const query = useRecoilValue(searchQueryState)
+
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>장르</h1>
-      <form onClick={addGenre}>
-        <ul className={styles.genreList}>
-          {genres.map((genre) => {
-            return (
-              <li key={genre}>
-                <input type="checkbox" />
-                <span>{genre}</span>
-              </li>
-            )
-          })}
-        </ul>
-      </form>
+      <ul className={styles.genreList}>
+        {genres.map((genre) => {
+          const queryString = generateQueryString<SearchQuery>({ ...query, genre })
+          let classes = `${styles.genre}`
+          if (genre === query.genre) classes += ` ${styles.current}`
+          return (
+            <li className={classes} key={genre}>
+              <Link to={'/search?' + queryString}>{genre}</Link>
+            </li>
+          )
+        })}
+      </ul>
     </div>
   )
 }

--- a/src/components/search/ProductList/index.tsx
+++ b/src/components/search/ProductList/index.tsx
@@ -1,236 +1,32 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useRecoilValue } from 'recoil'
 import styles from './index.module.scss'
 import Filter from '../Filter'
-import { SearchProductsResponse } from '@/types/product'
 import Product from '../Product'
-
-const dummyProducts: SearchProductsResponse = [
-  {
-    id: 'nbqtQvEiasfdTDet7YM',
-    title: '젤다의 전설 스카이워드 소드',
-    price: 30000,
-    description: '젤다의 전설 스카이워드 소드 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_hi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqSSQEutyEXTDet7YM',
-    title: '젤다의 전설 야숨',
-    price: 40000,
-    description: '젤다의 전설 야숨 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtQvjtaeEXTDet7YD',
-    title: '젤다의 전설 왕눈',
-    price: 50000,
-    description: '젤다의 전설 왕눈 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_search_image.webp',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtaefnSTDet7YM',
-    title: '젤다의 전설 꿈섬',
-    price: 60000,
-    description: '젤다의 전설 꿈구는 섬',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_dream_castle.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtASnfdTDet7YM',
-    title: '별의 커비 디스커버리',
-    price: 70000,
-    description: '별의 커비 디스커버리 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/curbi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nqwgvYwASDDet7YM',
-    title: '슈퍼마리오 파티',
-    price: 70000,
-    description: '슈퍼마리오 파티설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/suma_party_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtdfgdfbsDet7YM',
-    title: '젤다의 전설 스카이워드 소드',
-    price: 30000,
-    description: '젤다의 전설 스카이워드 소드 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_hi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqSrtbshEivYzxcDet7YM',
-    title: '젤다의 전설 야숨',
-    price: 40000,
-    description: '젤다의 전설 야숨 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nAVivYwEXTDet7YD',
-    title: '젤다의 전설 왕눈',
-    price: 50000,
-    description: '젤다의 전설 왕눈 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_search_image.webp',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtTRBHUKNYOvYwSzzSTDet7YM',
-    title: '젤다의 전설 꿈섬',
-    price: 60000,
-    description: '젤다의 전설 꿈구는 섬',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_dream_castle.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbrVdadDvYwSSTDet7YM',
-    title: '별의 커비 디스커버리',
-    price: 70000,
-    description: '별의 커비 디스커버리 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/curbi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqVredjnyadet7YM',
-    title: '슈퍼마리오 파티',
-    price: 70000,
-    description: '슈퍼마리오 파티설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/suma_party_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbgwerBUYNDdTDet7YM',
-    title: '젤다의 전설 스카이워드 소드',
-    price: 30000,
-    description: '젤다의 전설 스카이워드 소드 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_hi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbasabvcutyEXTDet7YM',
-    title: '젤다의 전설 야숨',
-    price: 40000,
-    description: '젤다의 전설 야숨 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqqwetneEXTDet7YD',
-    title: '젤다의 전설 왕눈',
-    price: 50000,
-    description: '젤다의 전설 왕눈 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_search_image.webp',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtaejhrzswTDet7YM',
-    title: '젤다의 전설 꿈섬',
-    price: 60000,
-    description: '젤다의 전설 꿈구는 섬',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_dream_castle.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbbzgeSnfdTDet7YM',
-    title: '별의 커비 디스커버리',
-    price: 70000,
-    description: '별의 커비 디스커버리 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/curbi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nqwbzsgeASDDet7YM',
-    title: '슈퍼마리오 파티',
-    price: 70000,
-    description: '슈퍼마리오 파티설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/suma_party_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtdfgdbzdrDet7YM',
-    title: '젤다의 전설 스카이워드 소드',
-    price: 30000,
-    description: '젤다의 전설 스카이워드 소드 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_hi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqSSxoryzxcDet7YM',
-    title: '젤다의 전설 야숨',
-    price: 40000,
-    description: '젤다의 전설 야숨 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqaxiovYwEXTDet7YD',
-    title: '젤다의 전설 왕눈',
-    price: 50000,
-    description: '젤다의 전설 왕눈 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_search_image.webp',
-    discountRate: 0
-  },
-  {
-    id: 'nnaeEpouet7YM',
-    title: '젤다의 전설 꿈섬',
-    price: 60000,
-    description: '젤다의 전설 꿈구는 섬',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/zelda_dream_castle.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtzaandfnafndTDet7YM',
-    title: '별의 커비 디스커버리',
-    price: 70000,
-    description: '별의 커비 디스커버리 설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/curbi_search_image.jpg',
-    discountRate: 0
-  },
-  {
-    id: 'nbqtndtjhsdadet7YM',
-    title: '슈퍼마리오 파티',
-    price: 70000,
-    description: '슈퍼마리오 파티설명',
-    tags: ['액션', '격투', 'RPG'],
-    thumbnail: '/images/search/suma_party_search_image.jpg',
-    discountRate: 0
-  }
-]
+import { filteredProductState } from '@/recoil/search/productState'
+import { SearchProductsResponse } from '@/types/product'
+import { searchQueryState } from '@/recoil/search/queryStringState'
 
 export default function ProductList() {
+  const searchQuery = useRecoilValue(searchQueryState)
+  const filterdProductsState = useRecoilValue(filteredProductState)
+  const [filteredProducts, setFilteredProducts] = useState<SearchProductsResponse>(filterdProductsState)
+
+  useEffect(() => {
+    setFilteredProducts(() => [...filterdProductsState])
+  }, [searchQuery])
+
   return (
     <div className={styles.container}>
       <Filter />
       <ul className={styles.list}>
-        {dummyProducts.map((product) => {
-          return <Product key={product.id} product={product} />
-        })}
+        {filteredProducts.length ? (
+          filteredProducts.map((product) => {
+            return <Product key={product.id} product={product} />
+          })
+        ) : (
+          <div>선택된 게임이 없습니다요</div>
+        )}
       </ul>
     </div>
   )

--- a/src/components/search/SearchBar/index.module.scss
+++ b/src/components/search/SearchBar/index.module.scss
@@ -1,0 +1,28 @@
+.container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+  margin-top: 2rem;
+  .cover {
+    position: relative;
+    width: 100%;
+    max-width: 790px;
+    height: 62px;
+    input {
+      display: block;
+      padding-left: 2rem;
+      width: 100%;
+      height: 100%;
+    }
+    .submit {
+      visibility: hidden;
+    }
+    .icon {
+      position: absolute;
+      top: 21px;
+      right: 20px;
+      width: 20px;
+      height: 20px;
+    }
+  }
+}

--- a/src/components/search/SearchBar/index.tsx
+++ b/src/components/search/SearchBar/index.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react'
+import styles from './index.module.scss'
+import { useNavigate } from 'react-router-dom'
+import { useRecoilValue } from 'recoil'
+import { SearchQuery, searchQueryState } from '@/recoil/search/queryStringState'
+import { generateQueryString } from '@/utils/search'
+
+export default function SearchBar() {
+  const naviagate = useNavigate()
+  const query = useRecoilValue(searchQueryState)
+  const [search, setSearch] = useState('')
+
+  function setSearchText(e: React.ChangeEvent<HTMLInputElement>) {
+    setSearch(e.target.value)
+  }
+
+  function submitSearch(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const params = generateQueryString<SearchQuery>({ ...query, search })
+    naviagate('/search?' + params.toString())
+  }
+  return (
+    <div className={styles.container}>
+      <form className={styles.cover} onSubmit={submitSearch}>
+        <input type="text" placeholder="검색" minLength={2} maxLength={10} required onChange={setSearchText} />
+        <label htmlFor="submitBtn">
+          <img
+            className={styles.icon}
+            width="20px"
+            height="20px"
+            src="/images/search/search_icon.svg"
+            alt="search icon"
+          />
+        </label>
+        <input id="submitBtn" className={styles.submit} type="submit" value="" />
+      </form>
+    </div>
+  )
+}
+//

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client'
 import './index.scss'
 import App from './App'
 import { BrowserRouter } from 'react-router-dom'
+import { RecoilRoot } from 'recoil'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
 root.render(
-	<BrowserRouter>
-		<App />
-	</BrowserRouter>
+  <RecoilRoot>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </RecoilRoot>
 )

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,10 +1,16 @@
+import React, { useEffect, Suspense } from 'react'
+import { useSetRecoilState } from 'recoil'
+import { SearchQuery, searchQueryState } from '@/recoil/search/queryStringState'
+
+import { useLocation } from 'react-router-dom'
+
 import SearchSwiper from '@/components/search/SearchSwiper'
 import Genre from '@/components/search/Genre'
-import React from 'react'
-import styles from './index.module.scss'
-import SearchHeader from '@/components/search/Search'
+import SearchBar from '@/components/search/SearchBar'
 import Banner from '@/components/search/Banner'
 import ProductList from '@/components/search/ProductList'
+
+import styles from './index.module.scss'
 
 const banners = [
   {
@@ -15,10 +21,23 @@ const banners = [
   }
 ]
 export default function Search() {
+  const location = useLocation()
+  const setQuery = useSetRecoilState(searchQueryState)
+
+  useEffect(() => {
+    setQuery(() => {
+      const params = new URLSearchParams(location.search)
+      const query = {} as SearchQuery
+      for (const [key, value] of params) {
+        query[key] = value
+      }
+      return { ...query }
+    })
+  }, [location.search])
+
   return (
     <main className={styles.container}>
       <div className={styles.containerWrapper}>
-        <SearchHeader />
         <SearchSwiper />
         <div className={styles.cover}>
           <Genre />
@@ -26,7 +45,10 @@ export default function Search() {
             {banners.map((banner) => (
               <Banner key={banner.id} banner={banner} />
             ))}
-            <ProductList />
+            <SearchBar />
+            <Suspense fallback={<div>Loading...</div>}>
+              <ProductList />
+            </Suspense>
           </div>
         </div>
       </div>

--- a/src/recoil/search/productState.ts
+++ b/src/recoil/search/productState.ts
@@ -1,0 +1,256 @@
+import { SearchProductsResponse } from './../../types/product'
+import { searchQueryState } from './queryStringState'
+import { atom, selector } from 'recoil'
+import { v1 } from 'uuid'
+
+export const dummyProducts: SearchProductsResponse = [
+  {
+    id: 'nbqtQvEiasfdTDet7YM',
+    title: '젤다의 전설 스카이워드 소드',
+    price: 30000,
+    description: '젤다의 전설 스카이워드 소드 설명',
+    tags: ['액션', '어드벤처', 'RPG'],
+    thumbnail: '/images/search/zelda_hi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqSSQEutyEXTDet7YM',
+    title: '젤다의 전설 야숨',
+    price: 40000,
+    description: '젤다의 전설 야숨 설명',
+    tags: ['액션', '격투', '보드'],
+    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtQvjtaeEXTDet7YD',
+    title: '젤다의 전설 왕눈',
+    price: 50000,
+    description: '젤다의 전설 왕눈 설명',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_search_image.webp',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtaefnSTDet7YM',
+    title: '젤다의 전설 꿈섬',
+    price: 60000,
+    description: '젤다의 전설 꿈구는 섬',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_dream_castle.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtASnfdTDet7YM',
+    title: '별의 커비 디스커버리',
+    price: 70000,
+    description: '별의 커비 디스커버리 설명',
+    tags: ['아케이드', '음악', '기타'],
+    thumbnail: '/images/search/curbi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nqwgvYwASDDet7YM',
+    title: '슈퍼마리오 파티',
+    price: 70000,
+    description: '슈퍼마리오 파티설명',
+    tags: ['보드', '커뮤니케이션', '슈팅'],
+    thumbnail: '/images/search/suma_party_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtdfgdfbsDet7YM',
+    title: '젤다의 전설 스카이워드 소드',
+    price: 30000,
+    description: '젤다의 전설 스카이워드 소드 설명',
+    tags: ['액션', '어드벤처', 'RPG'],
+    thumbnail: '/images/search/zelda_hi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqSrtbshEivYzxcDet7YM',
+    title: '젤다의 전설 야숨',
+    price: 40000,
+    description: '젤다의 전설 야숨 설명',
+    tags: ['액션', '격투', '보드'],
+    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nAVivYwEXTDet7YD',
+    title: '젤다의 전설 왕눈',
+    price: 50000,
+    description: '젤다의 전설 왕눈 설명',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_search_image.webp',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtTRBHUKNYOvYwSzzSTDet7YM',
+    title: '젤다의 전설 꿈섬',
+    price: 60000,
+    description: '젤다의 전설 꿈구는 섬',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_dream_castle.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbrVdadDvYwSSTDet7YM',
+    title: '별의 커비 디스커버리',
+    price: 70000,
+    description: '별의 커비 디스커버리 설명',
+    tags: ['아케이드', '음악', '기타'],
+    thumbnail: '/images/search/curbi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqVredjnyadet7YM',
+    title: '슈퍼마리오 파티',
+    price: 70000,
+    description: '슈퍼마리오 파티설명',
+    tags: ['보드', '커뮤니케이션', '슈팅'],
+    thumbnail: '/images/search/suma_party_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbgwerBUYNDdTDet7YM',
+    title: '젤다의 전설 스카이워드 소드',
+    price: 30000,
+    description: '젤다의 전설 스카이워드 소드 설명',
+    tags: ['액션', '어드벤처', 'RPG'],
+    thumbnail: '/images/search/zelda_hi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbasabvcutyEXTDet7YM',
+    title: '젤다의 전설 야숨',
+    price: 40000,
+    description: '젤다의 전설 야숨 설명',
+    tags: ['액션', '격투', '보드'],
+    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqqwetneEXTDet7YD',
+    title: '젤다의 전설 왕눈',
+    price: 50000,
+    description: '젤다의 전설 왕눈 설명',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_search_image.webp',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtaejhrzswTDet7YM',
+    title: '젤다의 전설 꿈섬',
+    price: 60000,
+    description: '젤다의 전설 꿈구는 섬',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_dream_castle.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbbzgeSnfdTDet7YM',
+    title: '별의 커비 디스커버리',
+    price: 70000,
+    description: '별의 커비 디스커버리 설명',
+    tags: ['아케이드', '음악', '기타'],
+    thumbnail: '/images/search/curbi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nqwbzsgeASDDet7YM',
+    title: '슈퍼마리오 파티',
+    price: 70000,
+    description: '슈퍼마리오 파티설명',
+    tags: ['보드', '커뮤니케이션', '슈팅'],
+    thumbnail: '/images/search/suma_party_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtdfgdbzdrDet7YM',
+    title: '젤다의 전설 스카이워드 소드',
+    price: 30000,
+    description: '젤다의 전설 스카이워드 소드 설명',
+    tags: ['액션', '어드벤처', 'RPG'],
+    thumbnail: '/images/search/zelda_hi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqSSxoryzxcDet7YM',
+    title: '젤다의 전설 야숨',
+    price: 40000,
+    description: '젤다의 전설 야숨 설명',
+    tags: ['액션', '격투', '보드'],
+    thumbnail: '/images/search/zelda_yasum_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqaxiovYwEXTDet7YD',
+    title: '젤다의 전설 왕눈',
+    price: 50000,
+    description: '젤다의 전설 왕눈 설명',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_search_image.webp',
+    discountRate: 0
+  },
+  {
+    id: 'nnaeEpouet7YM',
+    title: '젤다의 전설 꿈섬',
+    price: 60000,
+    description: '젤다의 전설 꿈구는 섬',
+    tags: ['액션', '격투', 'RPG'],
+    thumbnail: '/images/search/zelda_dream_castle.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtzaandfnafndTDet7YM',
+    title: '별의 커비 디스커버리',
+    price: 70000,
+    description: '별의 커비 디스커버리 설명',
+    tags: ['아케이드', '음악', '기타'],
+    thumbnail: '/images/search/curbi_search_image.jpg',
+    discountRate: 0
+  },
+  {
+    id: 'nbqtndtjhsdadet7YM',
+    title: '슈퍼마리오 파티',
+    price: 70000,
+    description: '슈퍼마리오 파티설명',
+    tags: ['보드', '커뮤니케이션', '슈팅'],
+    thumbnail: '/images/search/suma_party_search_image.jpg',
+    discountRate: 0
+  }
+]
+
+export const searchProductsState = atom<SearchProductsResponse>({
+  key: 'searchProductsState' + v1(),
+  default: dummyProducts
+})
+
+export const filteredProductState = selector<SearchProductsResponse>({
+  key: 'filteredProductList' + v1(),
+  get: async ({ get }) => {
+    const products = get(searchProductsState)
+    const sq = get(searchQueryState)
+    console.log(sq)
+    console.log('API가 실행됩니다. 1초뒤 결과과 반환됩니다.')
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    console.log('API 끝!')
+
+    if (!sq.genre && !sq.sort) {
+      return products
+    }
+    const filterdProducts = [...products]
+    if (!sq.sort || sq.sort === 'asc') {
+      filterdProducts.sort((a, b) => (a.title > b.title ? 1 : -1))
+    } else if (sq.sort === 'desc') {
+      filterdProducts.sort((a, b) => (b.title > a.title ? 1 : -1))
+    } else if (sq.sort === 'low') {
+      filterdProducts.sort((a, b) => a.price - b.price)
+    } else if (sq.sort === 'high') {
+      filterdProducts.sort((a, b) => b.price - a.price)
+    }
+    if (!sq.genre) return filterdProducts
+    return filterdProducts.filter((product) => product.tags.includes(String(sq.genre)))
+  }
+})

--- a/src/recoil/search/queryStringState.ts
+++ b/src/recoil/search/queryStringState.ts
@@ -1,0 +1,14 @@
+import { atom } from 'recoil'
+import { v1 } from 'uuid'
+
+export type SearchQuery = {
+  [key: string]: string | undefined
+  sort?: string
+  search?: string
+  genre?: string
+}
+
+export const searchQueryState = atom<SearchQuery>({
+  key: 'searchQueryState' + v1(),
+  default: {}
+})

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,18 @@
+type Params = {
+  [key: string]: unknown
+}
+export function generateQueryString<T extends Params>(params: T): string {
+  const ParamsOnlyStringValue: {
+    // * URLSearchParams의 value는 string만 허용합니다.
+    [key: string]: string
+  } = {}
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value == 'string') {
+      ParamsOnlyStringValue[key] = value
+      continue
+    }
+    throw new Error('params의 값은 문자열만 가능합니다.')
+  }
+  const queryString = new URLSearchParams(ParamsOnlyStringValue)
+  return queryString.toString()
+}


### PR DESCRIPTION
1. recoil을 사용해서 검색 필터 상태를 관리하는 로직을 추가했습니다. 
  - recoil/search/productState.ts 
  - queryStringState.ts 
2. /search 페이지 검색 필터 기능 html, css를 구현했습니다. 
  - component/search폴더를 참고해주세요. - pages/search.tsx를 참고해주세요. 
3. generateQueryString함수를 만들었습니다. 
  - URLSearchParams API를 사용해서 컴색 쿼리 객체를 문자열로 만들어주는 기능입니다. 
  - /utils/search.ts를 참고해주세요.