### PR TITLE
19 paymethod feature

### DIFF
--- a/src/components/payment/ShoppingCart.tsx
+++ b/src/components/payment/ShoppingCart.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import styles from './ShoppingCart.module.scss'
 import CartItem from './CartItem'
-import dummyGoods1 from '@/pages/payment/dummyGoods1.json'
-import dummyGoods2 from '@/pages/payment/dummyGoods2.json'
 import { Products, Product } from '@/types/product'
 import { useLocation } from 'react-router-dom'
 
@@ -25,7 +23,6 @@ export default function ShoppingCart({ getTotalValue }: Props) {
   //dummy라서 현재 라우터위치에서 저장함.
   //실제 api연동 후에는, 제품상세페이지에서 장바구니 담기 시 setItem 실행, getItem으로 받아오기만 할 것.
   useEffect(() => {
-    localStorage.setItem('cart', JSON.stringify([dummyGoods1, dummyGoods2]))
     setCart(JSON.parse(localStorage.getItem('cart') || '[]'))
   }, [])
 

--- a/src/components/payment/payMethod/BankConnect.tsx
+++ b/src/components/payment/payMethod/BankConnect.tsx
@@ -1,33 +1,20 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styles from './BankConnect.module.scss'
 import { getBankLogo } from './PossibleBank'
+import { AccountConnectionRequest } from '@/types/account'
 
 interface Props {
   bankName: string
   bankCode: string
   bankDigits: number[]
+  handleBankConnectData: (data: AccountConnectionRequest) => void
 }
 
-export default function BankConnection({ bankName, bankCode, bankDigits }: Props) {
+export default function BankConnection({ bankName, bankCode, bankDigits, handleBankConnectData }: Props) {
   const bankLogo = getBankLogo(bankName)
 
   const [accountNumber, setAccountNumber] = useState('')
   const [phoneNumber, setPhoneNumber] = useState('')
-
-  /*
-  {
-    "name": "KB국민은행",
-    "code": "004",
-    "digits": [3, 2, 4, 3],
-    "disabled": false
-  },
-*/
-  /*
-  bankCode: string // 연결할 은행 코드 (필수!)
-  accountNumber: string // 연결할 계좌번호 (필수!)
-  phoneNumber: string // 사용자 전화번호 (필수!)
-  signature: boolean // 사용자 서명 (필수!)
-  */
 
   const handleAccountNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -60,6 +47,16 @@ export default function BankConnection({ bankName, bankCode, bankDigits }: Props
     const formattedValue = inputDigits.slice(0, 11).replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
     setPhoneNumber(formattedValue)
   }
+
+  // api 사용에 필요한 requestbody 부모컴포넌트(payMethod 로 전달)
+  useEffect(() => {
+    handleBankConnectData({
+      bankCode: bankCode, // 연결할 은행 코드 (필수!)
+      accountNumber: accountNumber.replace(/-/g, ''), // 연결할 계좌번호 (필수!)
+      phoneNumber: phoneNumber.replace(/-/g, ''), // 사용자 전화번호 (필수!)
+      signature: true // 사용자 서명 (필수!)
+    })
+  }, [phoneNumber, accountNumber])
 
   return (
     <div className={styles.container}>
@@ -105,3 +102,55 @@ export default function BankConnection({ bankName, bankCode, bankDigits }: Props
     </div>
   )
 }
+
+// 2. 계좌 연결
+/*
+### 계좌 연결
+
+- 연결된 계좌 잔액에는 자동으로 기본 '3백만원'이 추가됩니다.
+- 요청하는 계좌번호와 전화번호에는``구분이 없어야 합니다.
+
+`curl https://asia-northeast3-heropy-api.cloudfunctions.net/api/account 
+  \ -X 'POST'
+  \ -H 'Authorization: Bearer <accessToken>'`
+
+요청 데이터 타입 및 예시:
+
+`interface RequestBody {
+  bankCode: string // 연결할 은행 코드 (필수!)
+  accountNumber: string // 연결할 계좌번호 (필수!)
+  phoneNumber: string // 사용자 전화번호 (필수!)
+  signature: boolean // 사용자 서명 (필수!)
+}`
+
+`{
+  "bankCode": "088",
+  "accountNumber": "123456789012",
+  "phoneNumber": "01012345678",
+  "signature": true
+}`
+
+응답 데이터 타입 및 예시:
+
+`interface ResponseValue { // 연결된 계좌 정보
+  id: string // 계좌 ID
+  bankName: string // 은행 이름
+  bankCode: string // 은행 코드
+  accountNumber: string // 계좌 번호
+  balance: number // 계좌 잔액
+}`
+  */
+/*
+  {
+    "name": "KB국민은행",
+    "code": "004",
+    "digits": [3, 2, 4, 3],
+    "disabled": false
+  },
+*/
+/*
+  bankCode: string // 연결할 은행 코드 (필수!)
+  accountNumber: string // 연결할 계좌번호 (필수!)
+  phoneNumber: string // 사용자 전화번호 (필수!)
+  signature: boolean // 사용자 서명 (필수!)
+  */

--- a/src/components/payment/payMethod/BankConnect.tsx
+++ b/src/components/payment/payMethod/BankConnect.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styles from './BankConnect.module.scss'
 import { getBankLogo } from './PossibleBank'
 
@@ -7,7 +7,14 @@ interface Props {
   bankCode: string
   bankDigits: number[]
 }
-/*
+
+export default function BankConnection({ bankName, bankCode, bankDigits }: Props) {
+  const bankLogo = getBankLogo(bankName)
+
+  const [accountNumber, setAccountNumber] = useState('')
+  const [phoneNumber, setPhoneNumber] = useState('')
+
+  /*
   {
     "name": "KB국민은행",
     "code": "004",
@@ -15,19 +22,48 @@ interface Props {
     "disabled": false
   },
 */
-/*
+  /*
   bankCode: string // 연결할 은행 코드 (필수!)
   accountNumber: string // 연결할 계좌번호 (필수!)
   phoneNumber: string // 사용자 전화번호 (필수!)
   signature: boolean // 사용자 서명 (필수!)
   */
 
-export default function BankConnection({ bankName, bankCode, bankDigits }: Props) {
-  const bankLogo = getBankLogo(bankName)
+  const handleAccountNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    // 입력된 숫자만 추출하여 문자열 생성
+    const inputDigits = value.replace(/[^0-9]/g, '')
+    let formattedValue = ''
+    let currentIndex = 0
+
+    for (let i = 0; i < bankDigits.length; i++) {
+      const digitCount = bankDigits[i]
+      const part = inputDigits.slice(currentIndex, currentIndex + digitCount)
+      if (part.length > 0) {
+        formattedValue += part
+
+        if (i < bankDigits.length - 1) {
+          formattedValue += '-'
+        }
+
+        currentIndex += digitCount
+      }
+    }
+    setAccountNumber(formattedValue)
+  }
+
+  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    // 입력된 숫자만 추출하여 문자열 생성
+    const inputDigits = value.replace(/[^0-9]/g, '')
+    // 정규표현식을 사용하여 포맷팅
+    const formattedValue = inputDigits.slice(0, 11).replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
+    setPhoneNumber(formattedValue)
+  }
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}> 계좌 등록</div>
+      <div className={styles.title}>계좌 등록</div>
       <div className={styles.mainContainer}>
         <div className={styles.bankTitle}>
           <div className={styles.bankLogo}>
@@ -39,13 +75,29 @@ export default function BankConnection({ bankName, bankCode, bankDigits }: Props
           <div className={styles.subContainer}>
             <div className={styles.subTitle}>계좌번호</div>
             <div className={styles.inputContainer}>
-              <input className={styles.input} type="text" />
+              <form>
+                <input
+                  className={styles.input}
+                  type="text"
+                  value={accountNumber}
+                  onChange={handleAccountNumberChange}
+                  placeholder="계좌번호를 입력해주세요!"
+                />
+              </form>
             </div>
           </div>
           <div className={styles.subContainer}>
             <div className={styles.subTitle}>전화번호</div>
             <div className={styles.inputContainer}>
-              <input className={styles.input} type="text" />
+              <form>
+                <input
+                  className={styles.input}
+                  type="text"
+                  value={phoneNumber}
+                  onChange={handlePhoneNumberChange}
+                  placeholder="전화번호를 입력해주세요!"
+                />
+              </form>
             </div>
           </div>
         </div>

--- a/src/pages/payment/dummyGoods1.json
+++ b/src/pages/payment/dummyGoods1.json
@@ -8,5 +8,5 @@
   "photo": "https://storage.googleapis.com/heropy-api/voihKb3NLGcv195257.png",
   "isSoldOut": false,
   "reservations": [],
-  "discountRate": 0
+  "discountRate": 10
 }

--- a/src/pages/payment/index.tsx
+++ b/src/pages/payment/index.tsx
@@ -12,6 +12,7 @@ export default function Payment() {
   //여기서 api 인증확인 한번 후 props로 데이터전달?
   const username = dummyUser.user.displayName
   localStorage.setItem('accessToken', dummyUser.accessToken)
+  //임시로 장바구니 set, 제품상세페이지에서 장바구니 클릭하면 추가하도록 하기
   localStorage.setItem('cart', JSON.stringify([dummyGoods1, dummyGoods2]))
 
   return (

--- a/src/pages/payment/index.tsx
+++ b/src/pages/payment/index.tsx
@@ -4,12 +4,15 @@ import PayProcessFlow from '@/components/payment/PayProcessFlow'
 import ShoppingCart from '@/components/payment/ShoppingCart'
 import Btn from '@/components/payment/Btn'
 import dummyUser from '@/pages/payment/dummyUser.json'
+import dummyGoods1 from '@/pages/payment/dummyGoods1.json'
+import dummyGoods2 from '@/pages/payment/dummyGoods2.json'
 
 export default function Payment() {
   //dummyLoginedUser
   //여기서 api 인증확인 한번 후 props로 데이터전달?
   const username = dummyUser.user.displayName
   localStorage.setItem('accessToken', dummyUser.accessToken)
+  localStorage.setItem('cart', JSON.stringify([dummyGoods1, dummyGoods2]))
 
   return (
     <div className={styles.background}>

--- a/src/pages/payment/payMethod/index.tsx
+++ b/src/pages/payment/payMethod/index.tsx
@@ -7,22 +7,45 @@ import { AccountsBalance } from '@/types/account'
 import { useNavigate } from 'react-router-dom'
 import Modal from '@/components/common/Modal'
 import dummyAccountsList from '@/pages/payment/dummyAccountsList.json'
-import { Banks } from '@/types/account'
+import { Banks, AccountConnectionRequest } from '@/types/account'
 import PossibleBank from '@/components/payment/payMethod/PossibleBank'
 import BankConnect from '@/components/payment/payMethod/BankConnect'
 import { Product } from '@/types/product'
 
 //사용되는 api
 // 1. 계좌 조회
-// 2. 계좌 연결
-// 3. 제품거래(구매) 신청
+// 3.제품거래(구매) 신청
+/*
+  ### 제품 거래(구매) 신청
+
+- 사용자 전용 API입니다.
+- 거래(구매) 신청시 연결된 계좌에서 결제됩니다.
+- 결제할 계좌(ID)를 꼭 선택해야 합니다.(`계좌 목록 및 잔액 조회`API를 사용하세요)
+- 선택한 계좌의 잔액보다 결제 금액이 크면 결제가 처리되지 않습니다.(에러 반환)
+
+`curl https://asia-northeast3-heropy-api.cloudfunctions.net/api/products/buy 
+  \ -X 'POST'
+  \ -H 'Authorization: Bearer <accessToken>'`
+
+요청 데이터 타입 및 예시:
+
+`interface RequestBody {
+  productId: string // 거래할 제품 ID (필수!)
+  accountId: string // 결제할 사용자 계좌 ID (필수!)
+  reservation?: { // 예약 정보(예약 시스템을 사용하는 경우만 필요)
+    start: string // 예약 시작 시간(ISO)
+    end: string // 예약 종료 시간(ISO)
+  }
+}`
+*/
 // 4. 선택가능한 은행 목록 조회
 
 // todo
 // 1. 총 계산금액 (할인율 포함) - 주문 금액, 할인율, 최종 결제 금액 표기 ✅
 // 2. 새로고침 시 모달 초기화 ✅
 // 3. 모달 계좌 연결 정보 입력 (정규식) ✅
-// 4. 계좌 데이터 연결(중요) -
+// 4. 계좌 데이터 연결(중요) -아아아아아
+// 5. api 불러와서 연동
 
 export default function PayMethod() {
   const { accounts }: AccountsBalance = dummyAccounts
@@ -34,6 +57,12 @@ export default function PayMethod() {
   const [nextModal, setNextModal] = useState(false)
   const [bankIndex, setBankIndex] = useState(0)
   const navigate = useNavigate()
+  const [BankConnectData, setBankConnectData] = useState<AccountConnectionRequest>({
+    bankCode: '',
+    accountNumber: '',
+    phoneNumber: '',
+    signature: true
+  })
 
   //cartItems 할인 계산
   const cartItems = JSON.parse(localStorage.getItem('cart') || '[]')
@@ -77,6 +106,35 @@ export default function PayMethod() {
     setNextModal(true)
     setBankIndex(index)
   }
+  //BankConnect컴포넌트서 가져올 데이터를 위한 Props함수
+  const handleBankConnectData = (data: AccountConnectionRequest) => {
+    setBankConnectData(data)
+  }
+
+  const handleBankConnectOrder = () => {
+    const accountNumLength = selectedAccount.digits.reduce((acc, val) => acc + val, 0)
+    if (BankConnectData.accountNumber.length !== accountNumLength) {
+      alert('올바른 계좌번호를 입력해주세요!')
+    } else if (BankConnectData.phoneNumber.length !== 10) {
+      alert('올바른 전화번호를 입력해주세요!')
+    } else {
+      // 수행할 로직
+      navigate('/payment/:username/orderComplete')
+    }
+    // api 은행 계좌 등록 요청. function(BankConnectData)
+    // 요청 완료 시 api 거래 신청 요청. accountId, productId 만 있으면 됨. function(BankConnectData.accountNumber, )
+    // 근데 productId가 배열데이터가 아님. 아
+    // 반복문 사용해서 productId만큼 요청보내기?
+    // 예외처리 - BankConnectData가 양식에 맞지 않을 경우, 올바른 계좌번호를 or 전화번호를 입력해주세요! alert보내기 ✅
+    // 아 어렵다
+    // 완료 시 navigate('/payment/:username/orderComplete')
+  }
+
+  const handleSelectedBankOrder = () => {
+    // api 거래 신청 요청.
+    // 완료시 navigate('/payment/:username/orderComplete')
+    navigate('/payment/:username/orderComplete')
+  }
 
   const selectedAccount = accountsList[bankIndex]
 
@@ -102,12 +160,7 @@ export default function PayMethod() {
               </div>
             </div>
             {isClicked && (
-              <button
-                className={styles.btn}
-                onClick={() => {
-                  navigate('/payment/:username/orderComplete')
-                }}
-              >
+              <button className={styles.btn} onClick={handleSelectedBankOrder}>
                 선택 계좌로 결제하기
               </button>
             )}
@@ -196,13 +249,9 @@ export default function PayMethod() {
               bankName={selectedAccount.name}
               bankCode={selectedAccount.code}
               bankDigits={selectedAccount.digits}
+              handleBankConnectData={handleBankConnectData}
             />
-            <button
-              className={styles.btn}
-              onClick={() => {
-                navigate('/payment/:username/orderComplete')
-              }}
-            >
+            <button className={styles.btn} onClick={handleBankConnectOrder}>
               계좌 등록 후 바로 결제하기
             </button>
           </div>

--- a/src/pages/payment/payMethod/index.tsx
+++ b/src/pages/payment/payMethod/index.tsx
@@ -10,12 +10,19 @@ import dummyAccountsList from '@/pages/payment/dummyAccountsList.json'
 import { Banks } from '@/types/account'
 import PossibleBank from '@/components/payment/payMethod/PossibleBank'
 import BankConnect from '@/components/payment/payMethod/BankConnect'
+import { Product } from '@/types/product'
 
 //사용되는 api
 // 1. 계좌 조회
 // 2. 계좌 연결
 // 3. 제품거래(구매) 신청
 // 4. 선택가능한 은행 목록 조회
+
+// todo
+// 1. 총 계산금액 (할인율 포함) - 주문 금액, 할인율, 최종 결제 금액 표기 ✅
+// 2. 새로고침 시 모달 초기화 ✅
+// 3. 모달 계좌 연결 정보 입력 (정규식) ✅
+// 4. 계좌 데이터 연결(중요) -
 
 export default function PayMethod() {
   const { accounts }: AccountsBalance = dummyAccounts
@@ -28,14 +35,27 @@ export default function PayMethod() {
   const [bankIndex, setBankIndex] = useState(0)
   const navigate = useNavigate()
 
+  //cartItems 할인 계산
+  const cartItems = JSON.parse(localStorage.getItem('cart') || '[]')
+  const orderPrice = cartItems.map((item: Product) => item.price).reduce((acc: number, cur: number) => acc + cur, 0)
+  const orderFinalPrice = cartItems
+    .map((item: Product) => item.price - (item.price * item.discountRate) / 100)
+    .reduce((acc: number, cur: number) => acc + cur, 0)
+  const discountPrice = orderPrice - orderFinalPrice
+
   useEffect(() => {
     setIsOpen(false)
     setIsClicked(false)
+    setIsModalOpen(false)
+    setNextModal(false)
+    setBankIndex(0)
   }, [])
 
   // 계좌 조회 버튼 핸들러
   const handleAccountsOpen = () => {
     setIsOpen(!isOpen)
+    setIsClicked(false)
+    setActiveIndex(null)
   }
   // 선택계좌 결제하기 버튼 생성 핸들러
   const handleBankOnClick = (index: number) => {
@@ -50,8 +70,9 @@ export default function PayMethod() {
   // 모달 닫기 핸들러
   const handleModalClose = () => {
     setIsModalOpen(false)
+    setNextModal(false)
   }
-
+  //다음 모달 핸들러
   const handleNextModal = (index: number) => {
     setNextModal(true)
     setBankIndex(index)
@@ -109,13 +130,13 @@ export default function PayMethod() {
               </div>
               <div className={styles.contents}>
                 <div className={styles.content}>
-                  <span>19,990</span>
+                  <span>{orderPrice}</span>
                 </div>
                 <div className={styles.content}>
                   <span>무료</span>
                 </div>
                 <div className={styles.content}>
-                  <span>0원</span>
+                  <span>{discountPrice}</span>
                 </div>
               </div>
             </div>
@@ -124,7 +145,7 @@ export default function PayMethod() {
                 <span>최종 결제 금액</span>
               </div>
               <div className={styles.price}>
-                <span>19,990</span>
+                <span>{orderFinalPrice}</span>
               </div>
             </div>
           </div>
@@ -182,7 +203,7 @@ export default function PayMethod() {
                 navigate('/payment/:username/orderComplete')
               }}
             >
-              계좌 등록 후 결제하기
+              계좌 등록 후 바로 결제하기
             </button>
           </div>
         )}

--- a/src/pages/payment/payMethod/index.tsx
+++ b/src/pages/payment/payMethod/index.tsx
@@ -10,19 +10,12 @@ import dummyAccountsList from '@/pages/payment/dummyAccountsList.json'
 import { Banks } from '@/types/account'
 import PossibleBank from '@/components/payment/payMethod/PossibleBank'
 import BankConnect from '@/components/payment/payMethod/BankConnect'
-import { Product } from '@/types/product'
 
 //사용되는 api
 // 1. 계좌 조회
 // 2. 계좌 연결
 // 3. 제품거래(구매) 신청
 // 4. 선택가능한 은행 목록 조회
-
-// todo
-// 1. 총 계산금액 (할인율 포함) - 주문 금액, 할인율, 최종 결제 금액 표기 ✅
-// 2. 새로고침 시 모달 초기화 ✅
-// 3. 모달 계좌 연결 정보 입력 (정규식) ✅
-// 4. 계좌 데이터 연결(중요) -
 
 export default function PayMethod() {
   const { accounts }: AccountsBalance = dummyAccounts
@@ -35,27 +28,14 @@ export default function PayMethod() {
   const [bankIndex, setBankIndex] = useState(0)
   const navigate = useNavigate()
 
-  //cartItems 할인 계산
-  const cartItems = JSON.parse(localStorage.getItem('cart') || '[]')
-  const orderPrice = cartItems.map((item: Product) => item.price).reduce((acc: number, cur: number) => acc + cur, 0)
-  const orderFinalPrice = cartItems
-    .map((item: Product) => item.price - (item.price * item.discountRate) / 100)
-    .reduce((acc: number, cur: number) => acc + cur, 0)
-  const discountPrice = orderPrice - orderFinalPrice
-
   useEffect(() => {
     setIsOpen(false)
     setIsClicked(false)
-    setIsModalOpen(false)
-    setNextModal(false)
-    setBankIndex(0)
   }, [])
 
   // 계좌 조회 버튼 핸들러
   const handleAccountsOpen = () => {
     setIsOpen(!isOpen)
-    setIsClicked(false)
-    setActiveIndex(null)
   }
   // 선택계좌 결제하기 버튼 생성 핸들러
   const handleBankOnClick = (index: number) => {
@@ -70,9 +50,8 @@ export default function PayMethod() {
   // 모달 닫기 핸들러
   const handleModalClose = () => {
     setIsModalOpen(false)
-    setNextModal(false)
   }
-  //다음 모달 핸들러
+
   const handleNextModal = (index: number) => {
     setNextModal(true)
     setBankIndex(index)
@@ -130,13 +109,13 @@ export default function PayMethod() {
               </div>
               <div className={styles.contents}>
                 <div className={styles.content}>
-                  <span>{orderPrice}</span>
+                  <span>19,990</span>
                 </div>
                 <div className={styles.content}>
                   <span>무료</span>
                 </div>
                 <div className={styles.content}>
-                  <span>{discountPrice}</span>
+                  <span>0원</span>
                 </div>
               </div>
             </div>
@@ -145,7 +124,7 @@ export default function PayMethod() {
                 <span>최종 결제 금액</span>
               </div>
               <div className={styles.price}>
-                <span>{orderFinalPrice}</span>
+                <span>19,990</span>
               </div>
             </div>
           </div>
@@ -203,7 +182,7 @@ export default function PayMethod() {
                 navigate('/payment/:username/orderComplete')
               }}
             >
-              계좌 등록 후 바로 결제하기
+              계좌 등록 후 결제하기
             </button>
           </div>
         )}


### PR DESCRIPTION
### 1. 총 계산금액 (할인율 포함) - 주문 금액, 할인율, 최종 결제 금액 표기 ✅
+ payMethod 페이지에서 요구하는 데이터는 3가지입니다.
+ 주문 금액 : 장바구니 아이템 가격의 단순 총 합산가격
+ 할인 : api에서는 퍼센트로 책정하는 것 같은데, 직접 할인된 가격을 표시하는게 더 직관적이기도 하고, 최종가를 계산하기도 편해서 할인된 가격을 표기했습니다.
+ 최종 결제 금액 : 주문 금액에서 할인된 가격을 뺀 가격입니다.

해당 데이터들은 localStorage에 있는 데이터를 가져다 쓰고, 페이지 내에서 재렌더링 될 일이 없어 state가 아닌 변수로 처리했습니다. 맞는지는 잘 모르겠네요.😅
### 2. 새로고침 시 모달 초기화 ✅
+ payMethod 페이지에서 useState를 통해 관리하던 boolean 값들을 useEffect를 통해 특정 이벤트마다 변하도록 관리했습니다.
실제로 데이터를 전달하는 부분은 컴포넌트에서 이루어지기에 boolean값만 변경하는 방식으로 생각보다 쉽게 구현할 수 있었습니다.
### 3. 모달 계좌 연결 정보 입력 (정규식) ✅
+ accountNumber는 선택가능 계좌조회 api로 받아온 Bank 타입의 digits 배열에 맞춰서 입력해야하므로 input에 정규식 대신 반복문으로(GPT야 고맙다) input 양식을 만들었습니다. BankConnect 컴포넌트의 handlAccountNumberChange 함수에 해당하는 부분입니다.
+ phoneNumber는 고정된 양식(010-xxxx-xxxx) 를 필요로 하므로 정규식을 사용하여 input 양식을 작성했습니다.

### 4. 계좌 데이터 연결(중요)
 + BankConnect컴포넌트에서 입력한 input데이터를 payMethod 페이지로 받아올 수 있도록 구현했습니다. 부모 컴포넌트에서 useState를 통해 좀 귀찮은 과정을 통해 자식컴포넌트의 데이터를 받아올수 있었습니다.
+ 해당 모달에서 결제 버튼을 누르면 발생하는 이벤트 핸들러의 의사코드까지 짜봤습니다.

### 5. api 불러와서 연동
+ 다음 issue에서 작성하도록 하겠습니다.

문제 되는 부분 있으면 말씀해주세요!