### PR TITLE
42 checkinfo connect api

### DIFF
--- a/src/apis/detail/index.ts
+++ b/src/apis/detail/index.ts
@@ -1,5 +1,6 @@
 import api from '@/apis'
 import { ProductDetail } from '@/types/product'
+
 export async function getProduct(productId: ProductDetail['id']) {
   const response = await api({
     method: 'GET',

--- a/src/components/common/UserHeader/index.tsx
+++ b/src/components/common/UserHeader/index.tsx
@@ -13,45 +13,8 @@ export default function UserHeader() {
   const [isLogined, setIsLogined] = useState(false)
   const [userInfo, setUserInfo] = useRecoilState(userState)
 
-  // 유저 정보 받아오기
+  // 1. localStorage에서 token 받아오기
   const accessToken = localStorage.getItem('token') || ''
-  // 1.여기서 accessToken으로 api 호출해서 user정보 확인을 해야할지?
-
-  const fetchUserInfo = async () => {
-    if (!isLogined) return
-    // api 호출함수 authenticate(accessToken) 호출
-    if (isLogined) {
-      try {
-        const userData = await getAuthenticatedUser(accessToken)
-        return setUserInfo(userData)
-      } catch (error) {
-        console.error(error)
-      }
-    }
-  }
-
-  const handleUserClick = () => {
-    setIsUserClicked(!isUserClicked)
-  }
-  // 스토리지에 access토큰이 변경될때 핸들링 이벤트
-  const handleStorageChange = (event: StorageEvent) => {
-    if (event.key === 'token') {
-      setIsLogined(!!localStorage.getItem('token'))
-    }
-  }
-
-  // 랜딩 시
-  useEffect(() => {
-    setCartItemCount(JSON.parse(localStorage.getItem('cart') || '[]').length)
-    setIsUserClicked(false)
-  }, [])
-
-  // fetchUserInfo 는 isLogined 감시해서 true면 호출
-  useEffect(() => {
-    if (isLogined) {
-      fetchUserInfo()
-    }
-  }, [isLogined, currentLocation])
 
   useEffect(() => {
     if (accessToken) {
@@ -61,32 +24,36 @@ export default function UserHeader() {
     }
   }, [accessToken])
 
-  // 숨텐도 옆에 현재 페이지의 타이틀을 대야함 ex) 결제, 마이페이지, 회원가입
-  // currentLocation이, url 주소에 있는 특정 단어를 포함하고 있으면 currentTitle이 바뀐다.
+  const fetchUserInfo = async () => {
+    if (!isLogined) return
+    // api 호출함수 authenticate(accessToken) 호출
+    if (isLogined) {
+      try {
+        console.log('로딩중..')
+        const userData = await getAuthenticatedUser(accessToken)
+        console.log(userData)
+        return setUserInfo(userData)
+      } catch (error) {
+        console.error(error, 'fetchUserInfo 오류1')
+      }
+    }
+  }
 
-  // 1.state currentTitle 을 선언. setCurrentTitle을 통해 바꾼다.
-  // 2. currentLocation을 통해 현재 라우트 주소 받아오기
-  // 3. 현재 라우트 주소에 해당 단어가 포함되어있는지 찾아보기
-  // 4. 포함되어 있다면, 경우에 따라 setCurrentTitle로 currentTitle을 바꾸기.
-
-  // 어떻게?
-  // includes 메서드로 현재 로케이션에 'payment', 'user', 'access'가 포함되어있는지 확인
-  // 그냥 쓰면 무한루프가 발생하므로 useEffect를 쓰자
-
+  // currentLocation == 라우터 주소. 변경 시 마다 발생할 일들
   useEffect(() => {
     if (currentLocation.includes('payment')) setCurrentTitle('결제')
     if (currentLocation.includes('user')) setCurrentTitle('마이페이지')
     if (currentLocation.includes('access')) setCurrentTitle('인증')
-  }, [currentLocation])
-
-  //로컬 스토리지에 이벤트 리스너 추가.
-  useEffect(() => {
-    window.addEventListener('storage', handleStorageChange)
-
-    return () => {
-      window.removeEventListener('storage', handleStorageChange)
+    setCartItemCount(JSON.parse(localStorage.getItem('cart') || '[]').length)
+    setIsUserClicked(false)
+    if (isLogined) {
+      fetchUserInfo()
     }
-  }, [])
+  }, [isLogined, currentLocation])
+
+  const handleUserClick = () => {
+    setIsUserClicked(!isUserClicked)
+  }
 
   return (
     <div className={styles.container}>

--- a/src/components/payment/Btn.tsx
+++ b/src/components/payment/Btn.tsx
@@ -5,9 +5,10 @@ import styles from './Btn.module.scss'
 export type BtnProps = {
   text: string
   targetURL: string
+  active?: boolean
 }
 
-export default function Btn({ text, targetURL }: BtnProps) {
+export default function Btn({ text, targetURL, active }: BtnProps) {
   const navigate = useNavigate()
 
   return (
@@ -18,6 +19,8 @@ export default function Btn({ text, targetURL }: BtnProps) {
           onClick={() => {
             navigate(`${targetURL}`)
           }}
+          disabled={active}
+          style={active ? { backgroundColor: '#e6011076', cursor: 'default' } : {}}
         >
           {text}
         </button>

--- a/src/components/payment/CartItem.module.scss
+++ b/src/components/payment/CartItem.module.scss
@@ -13,6 +13,10 @@
       height: auto;
       max-width: 200px;
       overflow: hidden;
+      .img {
+        width: 150px;
+        height: auto;
+      }
     }
     .info {
       flex: 1;

--- a/src/components/payment/ShoppingCart.tsx
+++ b/src/components/payment/ShoppingCart.tsx
@@ -3,16 +3,19 @@ import styles from './ShoppingCart.module.scss'
 import CartItem from './CartItem'
 import { Products, Product } from '@/types/product'
 import { useLocation } from 'react-router-dom'
+import { User } from '@/types/user'
 
 interface Props {
   getTotalValue?: (value: number) => void
+  user?: User
 }
-
-export default function ShoppingCart({ getTotalValue }: Props) {
+// localStorage에
+// 'cart' : [{},{}, {}, {}]' 이런 형태로 들어간다.
+// 추가로 객체 중 하나는 User 객체다.
+export default function ShoppingCart({ getTotalValue, user }: Props) {
   const [cart, setCart] = useState<Products>([])
-
   const currentLocation = useLocation()
-  const userName = useLocation().pathname.split('/')[2]
+  const userName = user?.displayName
 
   //카트아이템 지우기
   const handleRemoveCartItem = (index: number) => {
@@ -23,8 +26,6 @@ export default function ShoppingCart({ getTotalValue }: Props) {
   }
 
   //랜딩 시 장바구니 저장
-  //dummy라서 현재 라우터위치에서 저장함.
-  //실제 api연동 후에는, 제품상세페이지에서 장바구니 담기 시 setItem 실행, getItem으로 받아오기만 할 것.
   useEffect(() => {
     setCart(JSON.parse(localStorage.getItem('cart') || '[]'))
   }, [])
@@ -45,9 +46,10 @@ export default function ShoppingCart({ getTotalValue }: Props) {
       </div>
       <div className="cart-container">
         <ul className={styles.cartList}>
-          {cart.map((item: Product, index: number) => (
-            <CartItem key={index} item={item} onRemove={() => handleRemoveCartItem(index)} />
-          ))}
+          {cart.length > 0 &&
+            cart.map((item: Product, index: number) => (
+              <CartItem key={index} item={item} onRemove={() => handleRemoveCartItem(index)} />
+            ))}
         </ul>
       </div>
     </div>

--- a/src/components/payment/ShoppingCart.tsx
+++ b/src/components/payment/ShoppingCart.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import styles from './ShoppingCart.module.scss'
 import CartItem from './CartItem'
-import { Products, Product } from '@/types/product'
 import { useLocation } from 'react-router-dom'
 import { User } from '@/types/user'
+import { UserCart, UserCartItem } from '@/types/usercart'
 
 interface Props {
   getTotalValue?: (value: number) => void
@@ -11,11 +11,14 @@ interface Props {
 }
 // localStorage에
 // 'cart' : [{},{}, {}, {}]' 이런 형태로 들어간다.
-// 추가로 객체 중 하나는 User 객체다.
+// 각 객체에는 User + Product 타입이 들어간다.
+// 따라서 카트에 들어가는 객체는 Products타입이 아니라, User & Product의 유니온 타입이다.
+// 이 객체 타입을 지정해야함.
 export default function ShoppingCart({ getTotalValue, user }: Props) {
-  const [cart, setCart] = useState<Products>([])
+  const [cart, setCart] = useState<UserCart>([])
   const currentLocation = useLocation()
   const userName = user?.displayName
+  const userEmail = user?.email
 
   //카트아이템 지우기
   const handleRemoveCartItem = (index: number) => {
@@ -32,7 +35,7 @@ export default function ShoppingCart({ getTotalValue, user }: Props) {
 
   useEffect(() => {
     if (getTotalValue && currentLocation.pathname === `/payment/${userName}/checkInfo`) {
-      const total = cart.reduce((acc: number, item: Product) => acc + item.price, 0)
+      const total = cart.reduce((acc: number, item: UserCartItem) => acc + item.price, 0)
       getTotalValue(total)
     }
   }, [cart, currentLocation.pathname, getTotalValue])
@@ -46,10 +49,16 @@ export default function ShoppingCart({ getTotalValue, user }: Props) {
       </div>
       <div className="cart-container">
         <ul className={styles.cartList}>
-          {cart.length > 0 &&
-            cart.map((item: Product, index: number) => (
-              <CartItem key={index} item={item} onRemove={() => handleRemoveCartItem(index)} />
-            ))}
+          {/* 만약 userCart의 email과, 리코일의 user.email(props로 받아옴)이 다르다면? user.email과 일치하는 userCartItem을 출력한다. */}
+          {cart.length > 0 ? (
+            cart
+              .filter((item: UserCartItem) => item.email === userEmail)
+              .map((item: UserCartItem, index: number) => (
+                <CartItem key={index} item={item} onRemove={() => handleRemoveCartItem(index)} />
+              ))
+          ) : (
+            <div> 장바구니에 담긴 물건이 없습니다! </div>
+          )}
         </ul>
       </div>
     </div>

--- a/src/pages/payment/agreement/index.tsx
+++ b/src/pages/payment/agreement/index.tsx
@@ -2,15 +2,17 @@ import React, { useState, useEffect } from 'react'
 import styles from './index.module.scss'
 import PayProcessFlow from '@/components/payment/PayProcessFlow'
 import { useNavigate } from 'react-router-dom'
+import { userState } from '@/recoil/common/userState'
+import { useRecoilValue } from 'recoil'
 
 export default function Agreement() {
   const [check, setCheck] = useState([false, false, false] as boolean[])
   const [active, setActive] = useState(false)
-
+  const user = useRecoilValue(userState)
   const navigate = useNavigate()
 
   const handleBtnClick = () => {
-    navigate('/payment/:username/checkInfo')
+    navigate(`/payment/${user.displayName}/checkInfo`)
   }
 
   const handleCheckBoxChange = (index: number) => {

--- a/src/pages/payment/checkInfo/index.tsx
+++ b/src/pages/payment/checkInfo/index.tsx
@@ -3,16 +3,15 @@ import styles from './index.module.scss'
 import PayProcessFlow from '@/components/payment/PayProcessFlow'
 import ShoppingCart from '@/components/payment/ShoppingCart'
 import Btn from '@/components/payment/Btn'
-import dummyUser from '@/pages/payment/dummyUser.json'
+import { useRecoilValue } from 'recoil'
+import { userState } from '@/recoil/common/userState'
 
 export default function CheckInfo() {
   const [totalValue, setTotalValue] = useState(0)
-
-  //recoilState로 대체하기
-  // localStorage에 저장된 accessToken으로 User정보 fetch? (types : User)
-  // Recoil로 상태관리가 되고 있으면 헤더에서 fetch된 state를 갖다쓰면 되는가?!
-  // 일단 dummyUser.json 을 사용합시다.
-  const user = dummyUser.user
+  const user = useRecoilValue(userState)
+  //recoilState로 대체하기 ✔
+  // localStorage에 저장된 accessToken으로 User정보 fetch? (types : User) ✔
+  // Recoil로 상태관리가 되고 있으면 헤더에서 fetch된 state를 갖다쓰면 되는가?! ✔
 
   const getTotalValue = (value: number) => {
     setTotalValue(value)
@@ -42,7 +41,7 @@ export default function CheckInfo() {
           </div>
         </div>
       </div>
-      <ShoppingCart getTotalValue={getTotalValue} />
+      <ShoppingCart getTotalValue={getTotalValue} user={user} />
       <div className={styles.totals}>
         <div className={styles.mark}>
           <span>합계</span>

--- a/src/pages/payment/checkInfo/index.tsx
+++ b/src/pages/payment/checkInfo/index.tsx
@@ -1,17 +1,28 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styles from './index.module.scss'
 import PayProcessFlow from '@/components/payment/PayProcessFlow'
 import ShoppingCart from '@/components/payment/ShoppingCart'
 import Btn from '@/components/payment/Btn'
 import { useRecoilValue } from 'recoil'
 import { userState } from '@/recoil/common/userState'
+import { UserCart, UserCartItem } from '@/types/usercart'
 
 export default function CheckInfo() {
+  const [btnActive, setBtnActive] = useState(false)
   const [totalValue, setTotalValue] = useState(0)
   const user = useRecoilValue(userState)
   //recoilState로 대체하기 ✔
   // localStorage에 저장된 accessToken으로 User정보 fetch? (types : User) ✔
   // Recoil로 상태관리가 되고 있으면 헤더에서 fetch된 state를 갖다쓰면 되는가?! ✔
+
+  const userCart: UserCart = JSON.parse(localStorage.getItem('cart') || '[]')
+  const matchedUserCart = userCart.filter((item: UserCartItem) => item.email === user.email)
+
+  useEffect(() => {
+    if (matchedUserCart.length === 0) {
+      setBtnActive(true)
+    }
+  }, [matchedUserCart])
 
   const getTotalValue = (value: number) => {
     setTotalValue(value)
@@ -50,7 +61,7 @@ export default function CheckInfo() {
           <span>{`₩ ${totalValue.toLocaleString()}`}</span>
         </div>
       </div>
-      <Btn text="확인" targetURL={`/payment/${user.displayName}/payMethod`} />
+      <Btn text="확인" targetURL={`/payment/${user.displayName}/payMethod`} active={btnActive} />
     </>
   )
 }

--- a/src/pages/payment/index.tsx
+++ b/src/pages/payment/index.tsx
@@ -1,21 +1,31 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import styles from './index.module.scss'
 import PayProcessFlow from '@/components/payment/PayProcessFlow'
 import ShoppingCart from '@/components/payment/ShoppingCart'
 import Btn from '@/components/payment/Btn'
 import { userState } from '@/recoil/common/userState'
 import { useRecoilValue } from 'recoil'
+import { UserCart, UserCartItem } from '@/types/usercart'
 
 export default function Payment() {
+  const [btnActive, setBtnActive] = useState(false)
+
   const user = useRecoilValue(userState)
   const username = user.displayName
+  const userCart: UserCart = JSON.parse(localStorage.getItem('cart') || '[]')
+  const matchedUserCart = userCart.filter((item: UserCartItem) => item.email === user.email)
+  useEffect(() => {
+    if (matchedUserCart.length === 0) {
+      setBtnActive(true)
+    }
+  }, [matchedUserCart])
 
   return (
     <div className={styles.background}>
       <div className={styles.container}>
         <PayProcessFlow />
         <div className={styles.inner}>
-          <ShoppingCart />
+          <ShoppingCart user={user} />
           <div className={styles.notice}>
             <p className={styles.noticeP}>
               <span className={styles.strong}>구매하신 닌텐도 어카운트</span>로 귀속되며 즉시 다운로드 받으십쇼
@@ -29,7 +39,7 @@ export default function Payment() {
             </p>
             <p className={styles.noticeP}>🙌 예&#41; 서울특별시 강남구 지하벙커 305호 탐정사무소</p>
           </div>
-          <Btn text="확인" targetURL={`/payment/${username}/agreement`} />
+          <Btn text="확인" targetURL={`/payment/${username}/agreement`} active={btnActive} />
         </div>
       </div>
     </div>

--- a/src/pages/payment/index.tsx
+++ b/src/pages/payment/index.tsx
@@ -3,17 +3,12 @@ import styles from './index.module.scss'
 import PayProcessFlow from '@/components/payment/PayProcessFlow'
 import ShoppingCart from '@/components/payment/ShoppingCart'
 import Btn from '@/components/payment/Btn'
-import dummyUser from '@/pages/payment/dummyUser.json'
-import dummyGoods1 from '@/pages/payment/dummyGoods1.json'
-import dummyGoods2 from '@/pages/payment/dummyGoods2.json'
+import { userState } from '@/recoil/common/userState'
+import { useRecoilValue } from 'recoil'
 
 export default function Payment() {
-  //dummyLoginedUser
-  //여기서 api 인증확인 한번 후 props로 데이터전달?
-  const username = dummyUser.user.displayName
-  // localStorage.setItem('accessToken', dummyUser.accessToken)
-  //임시로 장바구니 set, 제품상세페이지에서 장바구니 클릭하면 추가하도록 하기
-  // localStorage.setItem('cart', JSON.stringify([dummyGoods1, dummyGoods2]))
+  const user = useRecoilValue(userState)
+  const username = user.displayName
 
   return (
     <div className={styles.background}>

--- a/src/types/usercart.ts
+++ b/src/types/usercart.ts
@@ -1,0 +1,8 @@
+//장바구니 타입
+//Product + User가 각 객체로 들어가는 타입임.
+import { Product } from './product'
+import { User } from './user'
+
+export type UserCart = UserCartItem[]
+
+export type UserCartItem = Product & User


### PR DESCRIPTION
### `root/payment/:username`, `root/payment/:username/checkInfo 경로에 user데이터를 연결했습니다.
UserHeader에서 저장한 recoil 상태를 이용하였습니다.

### payment와 checkInfo에서 공용으로 쓰는 컴포넌트인 Btn.tsx 가, 장바구니 목록이 없을 때 비활성화 되는 로직을 추가했습니다.
```
  const user = useRecoilValue(userState)
  const username = user.displayName
  const userCart: UserCart = JSON.parse(localStorage.getItem('cart') || '[]')
  const matchedUserCart = userCart.filter((item: UserCartItem) => item.email === user.email)
  useEffect(() => {
    if (matchedUserCart.length === 0) {
      setBtnActive(true)
    }
  }, [matchedUserCart])
  ```
  
  ### ShoppingCart 컴포넌트에서 localStorage의 'cart'항목의 각 아이템들이, 현재 로그인된 user가 추가한 정보가 맞는지 필터링하여 item을 출력합니다.
  ```
cart
  .filter((item: UserCartItem) => item.email === userEmail)
  .map((item: UserCartItem, index: number) => (
      <CartItem key={index} item={item} onRemove={() => 
            handleRemoveCartItem(index)} />
              ))
```

api 연동 부분은 딱히 없네요. payMethod 페이지에서 집중적으로 사용될 것 같습니다.