### PR TITLE
fix : logout hooks 비동기로 수정

### DIFF
--- a/src/apis/access/signOut/index.ts
+++ b/src/apis/access/signOut/index.ts
@@ -1,15 +1,17 @@
 import api from '@/apis'
 
-export async function signOut(accessToken: string) {
-  const response = await api({
-    method: 'POST',
-    url: '/api/auth/logout',
-    headers: {
-      Authorization: `Bearer ${accessToken}`
-    }
-  })
-
-  localStorage.removeItem('token')
-
-  return response.data
+export async function signOut(accessToken: string): Promise<boolean> {
+  try {
+    const response = await api({
+      method: 'POST',
+      url: '/api/auth/logout',
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    })
+    return response.data as boolean
+  } catch (error) {
+    console.error(error)
+    return false
+  }
 }

--- a/src/components/common/MainHeader/index.tsx
+++ b/src/components/common/MainHeader/index.tsx
@@ -7,7 +7,7 @@ import useUserInfo from '@/hooks/useUserInfo'
 export default function MainHeader() {
   const navigate = useNavigate()
   const [isOpen, setIsOpen] = useState(false)
-  const [userInfo, isLoggedIn, logout] = useUserInfo()
+  const [_, isLoggedIn] = useUserInfo()
 
   function handleSearchBtn() {
     setIsOpen(!isOpen)
@@ -15,6 +15,9 @@ export default function MainHeader() {
   function navigateSearchPage(searchText: string) {
     navigate(`/search?search=${searchText}`)
     setIsOpen(false)
+  }
+  function navigateLogoutPage() {
+    navigate(`/access/logout`)
   }
 
   return (
@@ -46,7 +49,7 @@ export default function MainHeader() {
           )}
           <li className={styles.login}>
             {isLoggedIn ? (
-              <div className={styles.item} onClick={logout}>
+              <div className={styles.item} onClick={navigateLogoutPage}>
                 <img src="/images/home/hardware.svg" alt="hardware icon" />
                 <p>로그 아웃</p>
               </div>

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -4,18 +4,23 @@ import { useRecoilState } from 'recoil'
 import { userState } from '@/recoil/common/userState'
 import { getAuthenticatedUser } from '@/apis/payment/access'
 import { User } from '@/types/user'
+import { signOut } from '@/apis/access/signOut'
 
-type UserInfoHooks = [UserInfoHooks: User, isLoggedIn: boolean, logout: () => void]
+type UserInfoHooks = [UserInfoHooks: User, isLoggedIn: boolean, logout: () => Promise<boolean>]
 
 const useUserInfo = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const [userInfo, setUserInfo] = useRecoilState(userState)
   const location = useLocation()
 
-  const logout = () => {
+  const logout = async () => {
+    let isLoggedOut = !isLoggedIn
+    const accessToken = localStorage.getItem('token')
+    if (accessToken) isLoggedOut = await signOut(accessToken)
     localStorage.removeItem('token')
     setIsLoggedIn(false)
     setUserInfo({} as User)
+    return isLoggedOut
   }
 
   useEffect(() => {

--- a/src/pages/access/logOut/index.tsx
+++ b/src/pages/access/logOut/index.tsx
@@ -9,14 +9,18 @@ export default function LogOut() {
   const navigate = useNavigate()
   const [userInfo, isLoggedIn, logout] = useUserInfo()
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     if (!isLoggedIn) {
       console.log('로그아웃 실패: 로그인 상태가 아닙니다.')
       return
     }
 
-    logout()
-    console.log('로그아웃 성공')
+    const isLoggedOut = await logout()
+    if (isLoggedOut) {
+      console.log('로그아웃 성공')
+    } else {
+      console.log('로그아웃 실패')
+    }
     navigate('/')
   }
 


### PR DESCRIPTION
#hooks/useUserInfo의 logout함수를 비동기로 수정했습니다.

`/apis/access/signOut` API와 `pages/access/logOut`의 로그아웃 로직에 약간의 변경이 있기 때문에 확인 부탁드립니다!