### PR TITLE
비밀번호변경페이지오류수정 및 불필요한 코드 삭제

### DIFF
--- a/src/pages/access/passwordChangeForm/index.tsx
+++ b/src/pages/access/passwordChangeForm/index.tsx
@@ -30,13 +30,12 @@ export default function PasswordChangeForm() {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
 
-    try {
-      // API 호출
-      await editedUserInfo({ oldPassword, newPassword }, accessToken)
-
+    // API 호출
+    const isEdited = await editedUserInfo({ oldPassword, newPassword }, accessToken)
+    if (isEdited) {
       alert('비밀번호가 변경되었습니다.')
       navigate('/')
-    } catch (error) {
+    } else {
       // 비밀번호 변경 실패 시 처리
       alert('비밀번호 변경에 실패했습니다. 확인 후 다시 시도해주세요.')
     }

--- a/src/pages/access/passwordCheck/index.tsx
+++ b/src/pages/access/passwordCheck/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent } from 'react'
+import React, { useState } from 'react'
 import styles from './index.module.scss'
 import { SignInRequest } from '@/types/auth'
 import { signIn } from '@/apis/access/signIn'

--- a/src/pages/access/signUpForm/index.tsx
+++ b/src/pages/access/signUpForm/index.tsx
@@ -83,16 +83,9 @@ export default function SignUpForm() {
         alert('회원가입 성공')
         navigate('/')
       } catch (error) {
-        console.log('폼 제출 실패')
         alert('회원가입에 실패했습니다.')
       }
     } else {
-      console.log('폼 제출 실패', {
-        email,
-        password,
-        displayName,
-        profileImgBase64: profileImage
-      })
       alert('회원가입에 실패했습니다.')
     }
   }


### PR DESCRIPTION
비밀번호변경페이지 기존비밀번호가 틀려도 메인페이지로 넘어가지는 오류 수정하였고 불필요한 콘솔로그 코드 삭제하였습니다.